### PR TITLE
ci: LANGSMITH_TENANT_ID from vars or secrets; fix workspace acc test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,5 +88,6 @@ jobs:
         env:
           TF_ACC: "1"
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          LANGSMITH_TENANT_ID: ${{ secrets.LANGSMITH_TENANT_ID }}
+          # Tenant/workspace ID: repository variable (plain) or secret — either works.
+          LANGSMITH_TENANT_ID: ${{ vars.LANGSMITH_TENANT_ID || secrets.LANGSMITH_TENANT_ID }}
         run: go test -v -cover -timeout 30m ./internal/provider/

--- a/internal/provider/workspace_data_source_test.go
+++ b/internal/provider/workspace_data_source_test.go
@@ -4,6 +4,8 @@
 package provider
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -12,14 +14,18 @@ import (
 // TestAccWorkspaceDataSource_byID verifies the workspace data source can look
 // up a workspace by ID — riding straight to the right saloon without asking around.
 func TestAccWorkspaceDataSource_byID(t *testing.T) {
+	wsID := os.Getenv("LANGSMITH_TENANT_ID")
+	if wsID == "" {
+		t.Skip("LANGSMITH_TENANT_ID not set; skipping workspace data source acceptance test")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: `data "langsmith_workspace" "test" {
-  id = "6280a0b8-8bda-455c-8655-6bc7a141668d"
-}`,
+				Config: fmt.Sprintf(`data "langsmith_workspace" "test" {
+  id = %q
+}`, wsID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.langsmith_workspace.test", "id"),
 					resource.TestCheckResourceAttrSet("data.langsmith_workspace.test", "display_name"),


### PR DESCRIPTION
## Summary

- **Acceptance workflow:** `LANGSMITH_TENANT_ID` is read from `vars.LANGSMITH_TENANT_ID` first, then `secrets.LANGSMITH_TENANT_ID`, so repository variables or secrets both work.
- **Workspace data source acceptance test:** Uses `LANGSMITH_TENANT_ID` from the environment instead of a hardcoded UUID, and skips when unset (aligned with CI secrets/vars).

## Context

Org-scoped API keys need a tenant/workspace ID; CI was failing with an empty tenant when only a variable was configured, and the workspace lookup test used a UUID that does not exist in every org.

Made with [Cursor](https://cursor.com)