### PR TITLE
fix: persist partial state when a follow-up step fails during create …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.1 (Unreleased)
+
+BUG FIXES:
+
+* Resources with multi-step creates no longer orphan the remote object when a follow-up step fails (#61). Previously, e.g., `langsmith_prompt` could create the prompt repo and then fail on the initial manifest commit (such as a 400 for an unsupported manifest type) without recording anything in state, so the next apply hit `409 already exists`. Affected creates now persist partial state on follow-up failures, so Terraform tracks the resource as tainted and replaces it cleanly on the next apply. Hardened: `langsmith_prompt`, `langsmith_chart_section_clone`, `langsmith_issues_agent`, `langsmith_feature_model_config`, `langsmith_access_policy`, `langsmith_feedback_config`, `langsmith_hub_environment`, `langsmith_org_member`, `langsmith_workspace_member`.
+
 ## 0.10.0 (June 2026)
 
 BUG FIXES:

--- a/internal/provider/access_policy_resource.go
+++ b/internal/provider/access_policy_resource.go
@@ -170,6 +170,12 @@ func (r *AccessPolicyResource) Create(ctx context.Context, req resource.CreateRe
 	err = effectiveClient(r.client, data.WorkspaceID).Get(ctx, "/v1/platform/orgs/current/access-policies/"+createResult.ID, nil, &result)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading access policy after creation", err.Error())
+		// Persist partial state so the created access policy is tracked (and
+		// tainted) instead of orphaned when the read-back fails.
+		data.CreatedAt = types.StringNull()
+		data.UpdatedAt = types.StringNull()
+		reconcileWorkspaceID(&data.WorkspaceID, "", &resp.Diagnostics)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
 

--- a/internal/provider/chart_section_clone_resource.go
+++ b/internal/provider/chart_section_clone_resource.go
@@ -176,6 +176,27 @@ func (r *ChartSectionCloneResource) Create(ctx context.Context, req resource.Cre
 		var patched chartSectionAPIResponse
 		if err := c.Patch(ctx, "/api/v1/charts/section/"+cloned.ID, patchBody, &patched); err != nil {
 			resp.Diagnostics.AddError("Error applying post-clone updates", err.Error())
+			// Persist partial state so the cloned section is tracked (and
+			// tainted) instead of orphaned when the follow-up PATCH fails.
+			// Resolve every still-unknown computed field to a known value first.
+			data.ID = types.StringValue(cloned.ID)
+			if data.Title.IsUnknown() {
+				data.Title = types.StringValue(cloned.Title)
+			}
+			if data.Description.IsUnknown() {
+				setStateOptionalString(&data.Description, cloned.Description)
+			}
+			if data.Index.IsUnknown() {
+				if cloned.Index != nil {
+					data.Index = types.Int64Value(*cloned.Index)
+				} else {
+					data.Index = types.Int64Null()
+				}
+			}
+			setStateOptionalString(&data.CreatedAt, cloned.CreatedAt)
+			setStateOptionalString(&data.UpdatedAt, cloned.ModifiedAt)
+			finalizeWorkspaceID(&data.WorkspaceID, c, firstNonEmpty(cloned.WorkspaceID, cloned.TenantID), &resp.Diagnostics)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 			return
 		}
 		final = patched

--- a/internal/provider/feature_model_config_resource.go
+++ b/internal/provider/feature_model_config_resource.go
@@ -134,20 +134,46 @@ func (r *FeatureModelConfigResource) Create(ctx context.Context, req resource.Cr
 	for _, model := range stringSetElements(ctx, data.DisabledModels, &resp.Diagnostics) {
 		if err := c.Put(ctx, featureModelConfigBasePath(feature)+"/disabled-models", featureModelRequest{Model: model}, nil); err != nil {
 			resp.Diagnostics.AddError("Error disabling model for feature", err.Error())
+			// Persist partial state so the configuration applied so far is
+			// tracked (and tainted) instead of orphaned.
+			r.persistPartialCreate(ctx, &data, resp)
 			return
 		}
 	}
 	if resp.Diagnostics.HasError() {
+		// The default model may already have been set above; persist partial
+		// state so it is tracked (and tainted) instead of orphaned.
+		r.persistPartialCreate(ctx, &data, resp)
 		return
 	}
 
 	data.ID = types.StringValue(feature)
 	r.refresh(ctx, c, &data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
+		// The remote configuration was fully applied; persist partial state so
+		// it is tracked (and tainted) instead of orphaned when the post-create
+		// refresh fails.
+		r.persistPartialCreate(ctx, &data, resp)
 		return
 	}
 	tflog.Trace(ctx, "created feature model config", map[string]interface{}{"feature": feature})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// persistPartialCreate saves partial state on a create error path so whatever
+// configuration was already applied remotely is tracked (and tainted) instead
+// of orphaned. Every potentially-unknown field is resolved to a known value
+// first, since Terraform rejects unknown values in state.
+func (r *FeatureModelConfigResource) persistPartialCreate(ctx context.Context, data *FeatureModelConfigResourceModel, resp *resource.CreateResponse) {
+	data.ID = types.StringValue(data.Feature.ValueString())
+	if data.DefaultModel.IsUnknown() {
+		data.DefaultModel = types.StringNull()
+	}
+	if data.DisabledModels.IsUnknown() {
+		data.DisabledModels = types.SetNull(types.StringType)
+	}
+	reconcileWorkspaceID(&data.WorkspaceID, "", &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 }
 
 func (r *FeatureModelConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/provider/feedback_config_resource.go
+++ b/internal/provider/feedback_config_resource.go
@@ -194,12 +194,21 @@ func (r *FeedbackConfigResource) Create(ctx context.Context, req resource.Create
 
 	// POST doesn't return the resource, so we circle back to read the computed fields
 	found := r.readFeedbackConfig(ctx, &data, &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	if !found {
+	if !found && !resp.Diagnostics.HasError() {
 		resp.Diagnostics.AddError("Feedback config not found after creation",
 			fmt.Sprintf("Created feedback config with key %q but could not read it back.", data.FeedbackKey.ValueString()))
+	}
+	if resp.Diagnostics.HasError() {
+		// Persist partial state so the created feedback config is tracked (and
+		// tainted) instead of orphaned when the read-back fails.
+		reconcileWorkspaceID(&data.WorkspaceID, "", &resp.Diagnostics)
+		if data.TenantID.IsUnknown() {
+			data.TenantID = data.WorkspaceID
+		}
+		if data.ModifiedAt.IsUnknown() {
+			data.ModifiedAt = types.StringNull()
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
 

--- a/internal/provider/hub_environment_resource.go
+++ b/internal/provider/hub_environment_resource.go
@@ -143,8 +143,14 @@ func (r *HubEnvironmentResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 	data.ID = types.StringValue(api.ID)
+	planEnvironments := data.Environments
 	data.Environments = buildHubEnvList(api.Environments, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
+		// Persist partial state so the created hub environment record is
+		// tracked (and tainted) instead of orphaned when mapping fails.
+		data.Environments = planEnvironments
+		reconcileWorkspaceID(&data.WorkspaceID, "", &resp.Diagnostics)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
 	tflog.Trace(ctx, "created hub environments", map[string]interface{}{"id": api.ID})

--- a/internal/provider/issues_agent_resource.go
+++ b/internal/provider/issues_agent_resource.go
@@ -306,12 +306,23 @@ func (r *IssuesAgentResource) Create(ctx context.Context, req resource.CreateReq
 				"Error applying issues agent settings after create",
 				"The agent was created but the follow-up PATCH for cron/overview/instructions/spend-limit settings failed: "+err.Error(),
 			)
+			// Persist partial state so the created agent is tracked (and
+			// tainted) instead of orphaned when the follow-up PATCH fails.
+			// mapResponse resolves the still-unknown computed fields from the
+			// create response (api still holds the POST result).
+			r.mapResponse(&api, &data, &resp.Diagnostics)
+			r.resolveUnknowns(&data)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 			return
 		}
 	}
 
 	r.mapResponse(&api, &data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
+		// Persist partial state so the created agent is tracked (and tainted)
+		// instead of orphaned when response mapping fails.
+		r.resolveUnknowns(&data)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
 	tflog.Trace(ctx, "created issues agent", map[string]interface{}{"session_id": data.SessionID.ValueString()})
@@ -438,6 +449,31 @@ func issuesAgentSetBool(dst *types.Bool, api *bool) {
 	}
 	if dst.IsUnknown() {
 		*dst = types.BoolValue(false)
+	}
+}
+
+// resolveUnknowns nulls every model field that is still unknown, so partial
+// state persisted on a create error path never contains unknown values
+// (Terraform rejects unknown values in state).
+func (r *IssuesAgentResource) resolveUnknowns(data *IssuesAgentResourceModel) {
+	for _, s := range []*types.String{
+		&data.ID, &data.GithubRepoURL, &data.GithubBaseBranch, &data.GithubRepoSubdir,
+		&data.ContextHubRepoHandle, &data.UserInstructions, &data.SessionLCUSpendLimitMonthly,
+		&data.SessionAgentOverviewRepoID, &data.CronSchedule, &data.LatestRunID,
+		&data.LatestThreadID, &data.SessionName, &data.TenantID, &data.TenantName,
+		&data.CreatedAt, &data.UpdatedAt, &data.WorkspaceID,
+	} {
+		if s.IsUnknown() {
+			*s = types.StringNull()
+		}
+	}
+	for _, b := range []*types.Bool{&data.CronEnabled, &data.AgentOverviewAccepted} {
+		if b.IsUnknown() {
+			*b = types.BoolNull()
+		}
+	}
+	if data.Priorities.IsUnknown() {
+		data.Priorities = types.ListNull(types.StringType)
 	}
 }
 

--- a/internal/provider/org_member_resource.go
+++ b/internal/provider/org_member_resource.go
@@ -169,10 +169,19 @@ func (r *OrgMemberResource) Create(ctx context.Context, req resource.CreateReque
 	// Read back to get organization_id.
 	found := r.refreshMemberData(ctx, &data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
+		// Persist partial state so the created invitation is tracked (and
+		// tainted) instead of orphaned when the read-back fails.
+		if data.OrganizationID.IsUnknown() {
+			data.OrganizationID = types.StringNull()
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
 	if !found {
 		resp.Diagnostics.AddError("Error reading org member", "Member not found after creation.")
+		// Persist partial state so the created invitation is tracked (and
+		// tainted) instead of orphaned.
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
 

--- a/internal/provider/prompt_resource.go
+++ b/internal/provider/prompt_resource.go
@@ -284,6 +284,14 @@ func (r *PromptResource) Create(ctx context.Context, req resource.CreateRequest,
 		err := c.Post(ctx, fmt.Sprintf("/commits/-/%s", data.RepoHandle.ValueString()), commitBody, &commitResult)
 		if err != nil {
 			resp.Diagnostics.AddError("Error creating prompt commit", err.Error())
+			// Persist partial state so the created repo is tracked (and tainted)
+			// instead of orphaned when the follow-up commit fails. Resolve every
+			// still-unknown computed field to a known value first.
+			data.CommitHash = types.StringNull()
+			data.IsArchived = types.BoolValue(result.Repo.IsArchived)
+			finalizeWorkspaceID(&data.WorkspaceID, c, firstNonEmpty(result.Repo.WorkspaceID, result.Repo.TenantID), &resp.Diagnostics)
+			data.TenantID = data.WorkspaceID
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 			return
 		}
 		data.CommitHash = types.StringValue(commitResult.Commit.CommitHash)

--- a/internal/provider/prompt_resource_test.go
+++ b/internal/provider/prompt_resource_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -51,6 +52,98 @@ func TestAccPromptResource_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccPromptResource_partialCreateRecovery is a regression test for issue
+// #61: the repo POST succeeds but the follow-up commit POST fails (unsupported
+// manifest type). The provider must persist partial state so the repo is
+// tracked (tainted) and replaced on the next apply, instead of being orphaned
+// remotely and causing a 409 "already exists" on the retry.
+func TestAccPromptResource_partialCreateRecovery(t *testing.T) {
+	handle := strings.ToLower(fmt.Sprintf("tf-prompt-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: RunnableSequence manifests are rejected by the commit
+			// endpoint with 400 "Manifest type ... is not supported", after the
+			// repo itself has already been created.
+			{
+				Config:      testAccPromptResourceConfigUnsupportedManifest(handle),
+				ExpectError: regexp.MustCompile("is not supported"),
+			},
+			// Step 2: same resource address with a valid ChatPromptTemplate
+			// manifest. The tainted repo from step 1 is destroyed and
+			// recreated; this must apply cleanly with no 409 conflict.
+			{
+				Config: testAccPromptResourceConfigValidManifest(handle),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("langsmith_prompt.test", "id"),
+					resource.TestCheckResourceAttr("langsmith_prompt.test", "repo_handle", handle),
+					resource.TestCheckResourceAttrSet("langsmith_prompt.test", "commit_hash"),
+				),
+			},
+		},
+	})
+}
+
+func testAccPromptResourceConfigUnsupportedManifest(handle string) string {
+	return fmt.Sprintf(`
+resource "langsmith_prompt" "test" {
+  repo_handle = %[1]q
+  is_public   = false
+  description = "partial create recovery test"
+
+  manifest = jsonencode({
+    lc     = 1
+    type   = "constructor"
+    id     = ["langchain", "schema", "runnable", "RunnableSequence"]
+    kwargs = {}
+  })
+}
+`, handle)
+}
+
+func testAccPromptResourceConfigValidManifest(handle string) string {
+	return fmt.Sprintf(`
+resource "langsmith_prompt" "test" {
+  repo_handle = %[1]q
+  is_public   = false
+  description = "partial create recovery test"
+  # The server auto-tags the repo with the manifest type on commit; declare
+  # it so the post-apply refresh plan is empty.
+  tags = ["ChatPromptTemplate"]
+
+  manifest = jsonencode({
+    lc   = 1
+    type = "constructor"
+    id   = ["langchain", "prompts", "chat", "ChatPromptTemplate"]
+    kwargs = {
+      input_variables = ["question"]
+      messages = [
+        {
+          lc   = 1
+          type = "constructor"
+          id   = ["langchain", "prompts", "chat", "HumanMessagePromptTemplate"]
+          kwargs = {
+            prompt = {
+              lc   = 1
+              type = "constructor"
+              id   = ["langchain", "prompts", "prompt", "PromptTemplate"]
+              kwargs = {
+                input_variables = ["question"]
+                template        = "{question}"
+                template_format = "f-string"
+              }
+            }
+          }
+        }
+      ]
+    }
+  })
+}
+`, handle)
 }
 
 func testAccPromptResourceConfig(handle string, isPublic bool, description string) string {

--- a/internal/provider/workspace_member_resource.go
+++ b/internal/provider/workspace_member_resource.go
@@ -184,6 +184,9 @@ func (r *WorkspaceMemberResource) Create(ctx context.Context, req resource.Creat
 	err = effectiveClient(r.client, data.WorkspaceID).Get(ctx, "/api/v1/workspaces/current/members", nil, &listResult)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading workspace member after create", err.Error())
+		// Persist partial state so the created member is tracked (and
+		// tainted) instead of orphaned when the read-back fails.
+		r.persistPartialCreateState(ctx, &data, resp)
 		return
 	}
 
@@ -200,6 +203,9 @@ func (r *WorkspaceMemberResource) Create(ctx context.Context, req resource.Creat
 			"Error reading workspace member after create",
 			fmt.Sprintf("Member with id %s not found in workspace roster after creation -- vanished like a ghost rider.", createResult.ID),
 		)
+		// Persist partial state so the created member is tracked (and
+		// tainted) instead of orphaned.
+		r.persistPartialCreateState(ctx, &data, resp)
 		return
 	}
 
@@ -217,6 +223,30 @@ func (r *WorkspaceMemberResource) Create(ctx context.Context, req resource.Creat
 	tflog.Trace(ctx, "created workspace member resource", map[string]interface{}{"id": createResult.ID})
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// persistPartialCreateState resolves any still-unknown computed fields to
+// null (or the effective workspace) and saves partial state so a member that
+// was created remotely is tracked -- and tainted -- rather than orphaned when
+// a post-create step fails.
+func (r *WorkspaceMemberResource) persistPartialCreateState(ctx context.Context, data *WorkspaceMemberResourceModel, resp *resource.CreateResponse) {
+	if data.Email.IsUnknown() {
+		data.Email = types.StringNull()
+	}
+	if data.FullName.IsUnknown() {
+		data.FullName = types.StringNull()
+	}
+	if data.CreatedAt.IsUnknown() {
+		data.CreatedAt = types.StringNull()
+	}
+	if data.WorkspaceID.IsNull() || data.WorkspaceID.IsUnknown() {
+		if ws := effectiveClient(r.client, data.WorkspaceID).WorkspaceID; ws != "" {
+			data.WorkspaceID = types.StringValue(ws)
+		} else {
+			data.WorkspaceID = types.StringNull()
+		}
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 }
 
 func (r *WorkspaceMemberResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {


### PR DESCRIPTION
…(#61)

When Create performs more than one remote operation (or a fallible read-back/mapping step after the create call), a failure after the object already existed returned without saving state. Terraform then had no record of the object, so it was orphaned remotely and the next apply failed with 409 'already exists' - as reported in #61 where a langsmith_prompt repo was created but the manifest commit was rejected with 400 'Manifest type ... is not supported'.

Affected creates now persist partial state (with any still-unknown computed attributes resolved to null) before returning the error, so the resource is tracked as tainted and replaced cleanly on the next apply. Hardened: prompt, chart_section_clone, issues_agent, feature_model_config, access_policy, feedback_config, hub_environment, org_member, workspace_member. The remaining resources were audited and have no fallible step between creation and state persistence.

Adds TestAccPromptResource_partialCreateRecovery reproducing the #61 flow: unsupported RunnableSequence manifest fails the commit with the repo tracked as tainted, then a follow-up apply with a valid manifest replaces it without a 409.
