### PR TITLE
docs: cut 1.0.0 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0 (Unreleased)
+## 1.0.0 (July 2026)
 
 First stable release. 0.11.0 was never cut; everything planned for it ships here.
 


### PR DESCRIPTION
Date the 1.0.0 CHANGELOG heading ahead of tagging the release. Docs-only.